### PR TITLE
Fix target showing as sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ HUD Notify is a mod that can be used display messages using HUD elements (instea
 - `/notify LegendaryGriefer Stop griefing or face a ban!`
 - `/notify_all Attention! The server will be shutting down for maintenance in 15 minutes.`
 
-### minetest.conf
+### Mod Settings
 
 - `hud_notify.hud_duration`
   - Stores a numeric value (10 by default) which represents the duration of the message visibility in seconds.

--- a/description.txt
+++ b/description.txt
@@ -1,3 +1,0 @@
-Shows a message to a player in-game, by means of an HUD element.
-
-Syntax: /notify <player_name> <msg>

--- a/init.lua
+++ b/init.lua
@@ -52,8 +52,7 @@ local function notify(sender, name, msg)
 			offset = {x = 70, y = 200},
 			alignment = {x = 1, y = 0},
 			number = 0xFFCC00,
-			text = msg_header,
-			text = "hud_notify_bg.png"
+			text = msg_header
 		})
 	end
 end

--- a/init.lua
+++ b/init.lua
@@ -10,7 +10,7 @@ local players = {}
 local duration = tonumber(minetest.settings:get("hud_notify.duration")) or 10
 local hide_sender = minetest.settings:get_bool("hud_notify.hide_sender") or false
 
-local function notify(name, msg)
+local function notify(sender, name, msg)
 	local player = minetest.get_player_by_name(name)
 
 	-- If notification is already being shown modify
@@ -20,7 +20,7 @@ local function notify(name, msg)
 		player:hud_change(players[name].msg, "text", msg)
 		if not hide_sender then
 			player:hud_change(players[name].header, "text",
-								"Notification from " .. name .. ": ")
+								"Notification from " .. sender .. ": ")
 		end
 		return
 	end
@@ -45,14 +45,15 @@ local function notify(name, msg)
 	})
 
 	if not hide_sender then
-		local msg_header = "Notification from " .. name .. ": "
+		local msg_header = "Notification from " .. sender .. ": "
 		players[name].header = player:hud_add({
 			hud_elem_type = "text",
 			position = {x = 0, y = 0},
 			offset = {x = 70, y = 200},
 			alignment = {x = 1, y = 0},
-			number = 0x3399FF,
-			text = msg_header
+			number = 0xFFCC00,
+			text = msg_header,
+			text = "hud_notify_bg.png"
 		})
 	end
 end
@@ -83,11 +84,11 @@ minetest.register_chatcommand("notify", {
 		if not pname or not msg then
 			return false, "Invalid usage, see /help notify."
 		end
-		if not core.get_player_by_name(pname) then
+		if not minetest.get_player_by_name(pname) then
 			return false, "The player " .. pname .. " is not online."
 		end
 
-		notify(pname, msg)
+		notify(name, pname, msg)
 		return true, "Notification sent to " .. pname .. ": \"" .. msg .. "\""
 	end
 })
@@ -103,7 +104,7 @@ minetest.register_chatcommand("notify_all", {
 		end
 
 		for _, player in pairs(minetest.get_connected_players()) do
-			notify(player:get_player_name(), msg)
+			notify(name, player:get_player_name(), msg)
 		end
 		return true, "Global notification sent: \"" .. msg .. "\""
 	end

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,5 +1,5 @@
 #Time in seconds how long a notification will be displayed.
-hud_notify.duration (Display Duration) int 10 1 60
+hud_notify.duration (Display Duration) int 10 1 180
 
 #Hides the sender of a notification.
 hud_notify.hide_sender (Hide Sender) bool false

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,4 +1,4 @@
-#Time in seconds how long a notification will be displayed.
+# Time in seconds how long a notification will be displayed.
 hud_notify.duration (Display Duration) int 10 1 180
 
 #Hides the sender of a notification.

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,5 +1,5 @@
 # Time in seconds how long a notification will be displayed.
 hud_notify.duration (Display Duration) int 10 1 180
 
-#Hides the sender of a notification.
+# Hides the sender of a notification.
 hud_notify.hide_sender (Hide Sender) bool false

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,5 @@
+#Time in seconds how long a notification will be displayed.
+hud_notify.duration (Display Duration) int 10 1 60
+
+#Hides the sender of a notification.
+hud_notify.hide_sender (Hide Sender) bool false


### PR DESCRIPTION
This PR fixes targets in `/notify player message` showing as the sender of the notification.